### PR TITLE
Fix unicorn plugin import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /** @type {import("eslint").Linter.Config}  */
 const defaultConfig = {
   extends: ['plugin:@typescript-eslint/recommended', 'prettier'],
-  plugins: ['import'],
+  plugins: ['import', 'unicorn'],
   rules: {
     'no-restricted-syntax': [
       'warn',


### PR DESCRIPTION
Fix error "ESLint: Definition for rule 'unicorn/prefer-ternary' was not found.(unicorn/prefer-ternary)"